### PR TITLE
Add cluster host to the plugins response

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -538,6 +538,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             "cluster": self.extract_cluster,
             "cluster_group": self.extract_cluster_group,
             "cluster_type": self.extract_cluster_type,
+            "cluster_device": self.extract_cluster_device,
             "is_virtual": self.extract_is_virtual,
             "serial": self.extract_serial,
             "asset_tag": self.extract_asset_tag,
@@ -946,6 +947,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             return self.clusters_type_lookup[host["cluster"]["id"]]
         except Exception:
             return
+
+    def extract_cluster_device(self, host):
+        return host.get("device")
 
     def extract_is_virtual(self, host):
         return host.get("is_virtual")


### PR DESCRIPTION
Cluster host (for VMs) is not yet part of the plugin response and neither available as a `host_var`. This will add back the cluster host so it becomes available as `cluster_device[]`.

For example, a VM will now have:
```
    "cluster_device": {
        "display": "proxmox-host-01",
        "id": 01,
        "name": "proxmox-host-01",
        "url": "https://net.box/api/dcim/devices/01/"
    },

```

